### PR TITLE
Code Samples in Docs

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -1,36 +1,54 @@
 # Managing authorization
 
-With Marionete.Routing is possible to implement authorization in a simple, flexible and effective manner 
+With Marionete.Routing is possible to implement authorization in a simple, flexible and effective manner
 
 ### Using `Route.activate` method
 
 Inside `activate` method of a Route class, check for the user authorization info and take the appropriate action.
-Is possible to cancel the transition or redirect to another route.   
+Is possible to cancel the transition or redirect to another route.
 
 ```javascript
 import {Route} from 'marionette.routing';
 import {checkAuth} from './my-auth-service'
 
-export default Route.extend({
+export const IndexRoute = Route.extend({
   activate (transition) {
     if (!checkAuth()) {
       transition.redirectTo('login')
       //alternatively
       //transition.cancel()
-    } 
-  } 
+    }
+  }
 });
-```    
+```
 
-Since the children routes are always activated after the parent ones, is necessary to check the authorization info
-only in the parent route. 
+Since the children routes are always activated after the parent ones, we only
+need to test for authentication in the parent route:
+
+```javascript
+import {IndexRoute} from './my-route';
+
+
+router.map(function (route) {
+  // Since this top-level route checks authentication, nothing below it needs to
+  route('application', {path: '/', routeClass: IndexRoute}, function () {
+    route('contacts', {routeClass: ContactsRoute})
+    route('login', {viewClass: LoginView})
+  })
+});
+```
 
 ### Using `before:activate` event
 
-The above method is simpler than most techniques used in JavaScript applications but there are some drawbacks. At the time the authorization check is done, the parent routes will be already activated and, if the transition is cancelled or redirected, there's the potential to trigger wasteful actions. Also if there are more than one route to be protected and one is not parent of other, is necessary to implement the same pattern for each route.  
+The above method is simpler than most techniques used in JavaScript applications
+but there are some drawbacks. At the time the authorization check is done, the
+parent routes will be already activated and, if the transition is cancelled or
+redirected, there's the potential to trigger wasteful actions. Also if there are
+more than one route to be protected and one is not parent of other, is necessary
+to implement the same pattern for each route.
 
-By using `before:activate` event, is possible to overcome those problems keeping the simplicity. The same behavior as above
-can be implemented with:
+By using `before:activate` event, is possible to overcome those problems keeping
+the simplicity. The same behavior as above can be implemented with:
 
 ```js
 import Radio from 'backbone.radio';
@@ -52,8 +70,10 @@ In a route that requires to check authorization
 import {Route} from 'marionette.routing';
 
 export default Route.extend({
-  requiresAuth: true 
+  requiresAuth: true
 });
-```    
+```
 
-This [live example](http://codepen.io/blikblum/pen/mWmbQX?editors=1010) demonstrates how to implement a refined authorization design, with different access levels and redirect from login to the original requested path 
+This [live example](http://codepen.io/blikblum/pen/mWmbQX?editors=1010)
+demonstrates how to implement a refined authorization design, with different
+access levels and redirect from login to the original requested path.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,18 +1,21 @@
 # Router Configuration
- 
-### `createRouter(options)`
- 
- Returns a cherrytree router instance. Accepts an options hash as argument:
 
- * **options.log** - a function that is called with logging info, default is noop. Pass in `true`/`false` or a custom logging function.
- * **options.logError** - default is true. A function that is called when transitions error (except for the special `TransitionRedirected` and `TransitionCancelled` errors). Pass in `true`/`false` or a custom error handling function.
- * **options.pushState** - default is false, which means using hashchange events. Set to `true` to use pushState.
- * **options.root** - default is `/`. Use in combination with `pushState: true` if your application is not being served from the root url /.
- * **options.interceptLinks** - default is true. When pushState is used - intercepts all link clicks when appropriate, prevents the default behaviour and instead uses pushState to update the URL and handle the transition via the router. You can also set this option to a custom function that will get called whenever a link is clicked if you want to customize the behaviour. Read more on [intercepting links below](#intercepting-links).
- * **options.qs** - default is a simple built in query string parser. Pass in an object with `parse` and `stringify` functions to customize how query strings get treated.
- * **options.Promise** - default is window.Promise or global.Promise. Promise implementation to be used when constructing transitions.
+## `createRouter(options)`
 
-### `router.map(fn)`
+ Returns a router instance. Accepts an options hash as argument:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `log`  | `noop` | Called with logging info - takes `true`, `false` or a custom logging function |
+| `logError` | `true` | Called when transitions error (except `TransitionRedirected` and `TransitionCancelled`). Takes `true`, `false`, or a custom function |
+| `pushState` | `false` | Use browser History API or the default hash change |
+| `root` | `/` | Used in combination with `pushState: true` - if your app isn't served from `/`, pass the new root |
+| `interceptLinks` | (same as `pushState`) | When `pushState: true` this intercepts all link clicks, preventing the default behavior. This can take a function to set custom behavior - see [intercepting links](#intercepting-links) |
+| `qs` | `object` | The parser function for query strings with a simple parser. Pass in an object with `parse` and `stringify` functions to customize the handling of query strings. |
+| `promise` | `window.Promise` | The Promises implementation to use for transitions |
+
+
+## `router.map(fn)`
 
 Configure the router with a route map. e.g.
 
@@ -29,31 +32,30 @@ router.map(function (route) {
 
 Each route can be configure with the following options:
 
- * routeClass: a Route class
- * routeOptions: options passed to the Route constructor
- * viewClass: a Marionette.View class. Can be used alone or with routeClass
- * viewOptions: options passed to the Marionette.View constructor
- * path: the route path
- * abstract: pass true to define an abstract route
- * outlet: pass true to allow a viewClass without a outlet region
+ * `routeClass`: a [`Route`](./route.md) class
+ * `routeOptions`: options passed to the Route constructor
+ * `viewClass`: a `Marionette.View` class. Can be used alone or with `routeClass`
+ * `viewOptions`: options passed to the Marionette.View constructor
+ * `path`: the route path
+ * `abstract`: pass true to define an abstract route
+ * `outlet`: pass true to allow a viewClass without an `outlet` region
 
-All routes must have at least viewClass or routeClass defined.
+**All routes must have at least viewClass or routeClass defined.**
 
 For more information about route mapping refer to cherrytree documentation
- 
-### `router.listen`
- 
+
+## `router.listen`
+
  Starts listening for URL changes
 
-### `router.rootRegion`
- 
+## `router.rootRegion`
+
  Property that defines the region where the top level views will be rendered
 
-### `middleware`
- 
-  A cherrytree middleware to be used by the route. Probably will be removed from public interface in the future  
+## `middleware`
 
-### `destroyRouter(routerInstance)`   
+  A cherrytree middleware to be used by the route. May be removed from public interface in the future.
 
-  Cleanup a router. Mostly used in tests
-    
+## `destroyRouter(routerInstance)`
+
+  Cleanup a router. This is mostly used for testing.

--- a/docs/route.md
+++ b/docs/route.md
@@ -1,17 +1,17 @@
 # Route Class
 
   The base class for defining routes. Extends from Marionette.Object
-  
+
 ## Methods
-  
+
 ### <code>activate(transition) [-> Promise]</code>
- 
+
  Called when route is about to be activated
- 
- The transition argument provides information about the routes being 
+
+ The transition argument provides information about the routes being
  transitioned to and methods to manipulate the transition like
  cancel and redirectTo
- 
+
  If a Promise is returned, the route activation is complete only after
  the Promise resolution
 
@@ -19,48 +19,130 @@
 
  Called when route is about to be deactivated
 
- The transition argument provides information about the routes being 
+ The transition argument provides information about the routes being
  transitioned to and methods to manipulate the transition like
  cancel and redirectTo
 
 ### <code>getContext</code>
- 
- Returns a route context object. 
- 
- The context object provides two methods: trigger and requests both with 
- the same semantics as the used in Radio. The events and requests will be handled
- by one of the parent routes through contextEvents and contextRequests 
 
-   
+ Returns a route context object.
+
+ The context object provides two methods: trigger and requests both with
+ the same semantics as the used in Radio. The events and requests will be handled
+ by one of the parent routes through
+ [`contextEvents`](#contextEvents) and [`contextRequests`](#contextRequests).
+
+```js
+const NoteEditRoute = Route.extend({
+  viewClass: NoteEditView,
+
+  viewOptions() {
+    return {
+      model: this.getContext().request('noteModel')
+    };
+  }
+})
+```
+
 ### <code>updateView(transition)</code>
- 
- Called when the view associated with the route is about to be re-rendered. 
- 
+
+ Called when the view associated with the route is about to be re-rendered.
+
 Allows to configure how a view already rendered will be updated. Returning
 a truthy value will prevent the default behavior (render a new view)
-   
-## Properties    
+
+## Properties
 
 ### <code>viewClass</code>
- 
+
  Defines the Marionette.View that will be rendered when the route is activated
- 
+
+```js
+const NoteRoute = Route.extend({
+  viewClass: NoteLayoutView
+});
+```
+
 ### <code>viewOptions</code>
-  
+
  Defines the options to be passed in the Marionette.View constructor
- 
+
+```js
+const NoteListRoute = Route.extend({
+  viewClass: NoteListView,
+
+  activate() {  // See activate below
+    this.collection = new NoteCollection();
+    this.collection.fetch();
+  },
+
+  viewOptions() {
+    return {
+      collection: this.collection
+    };
+  }
+});
+```
+
 ### <code>viewEvents</code>
-   
+
  A hash defining listeners for the events triggered by the view
- 
+
+```js
+const NoteCreateRoute = Route.extend({
+  viewClass: NoteCreateView,
+
+  viewEvents: {
+    'note:created': 'addNoteToCollection'
+  },
+
+  addNoteToCollection(model) {
+    this.collection.add(model);
+    Radio.channel('router').request('transitionTo', 'note.list');
+  }
+})
+```
+
 ### <code>contextRequests</code>
-    
- A hash defining reply functions to requests done by child routes through getContext
- 
+
+ A hash defining reply functions to requests done by [child routes](#childRoutes)
+ through [getContext](#getContext)
+
+```js
+const NoteDetailRoute = Route.extend({
+  // ...
+  childRoutes: {
+    'note.edit': NoteEditRoute  // See childRoutes below
+  },
+
+  activate(transition) {  // See activate above
+    this.noteModel = new NoteModel({ id: parseInt(transition.params.noteId) });
+    this.noteModel.fetch();
+  },
+
+  contextRequests: {
+    noteModel() {
+      return this.noteModel;
+    }
+  }
+})
+```
+
 ### <code>contextEvents</code>
-    
- A hash defining listeners to events triggered by child routes through getContext
-  
+
+ A hash defining listeners to events triggered by [child routes](#childRoutes)
+ through [getContext](#getContext)
+
 ### <code>childRoutes</code>
-    
- A hash defining route definitions for children routes   
+
+ A hash defining route definitions for children routes
+
+```js
+const NoteRoute = Route.extend({
+  childRoutes: {
+    'note.list': NoteListRoute,
+    'note.detail': NoteDetailRoute,
+    'note.create': NoteCreateRoute
+  }
+});
+```


### PR DESCRIPTION
I've added a few code samples to the documentation for `marionette.routing` to try and clarify a few things and give an example of how everything works.

Hopefully this will help new users getting started with the module on the back of the blog post I'm writing.