### PR TITLE
viewClass can now be an instance of CollectionView

### DIFF
--- a/src/route.js
+++ b/src/route.js
@@ -1,6 +1,6 @@
 import _ from 'underscore'
 import Radio from 'backbone.radio'
-import { MnObject, View, bindEvents, unbindEvents } from 'backbone.marionette'
+import { MnObject, CollectionView, View, bindEvents, unbindEvents } from 'backbone.marionette'
 import RouteContext from './routecontext'
 import { getMnRoutes, routerChannel } from './cherrytree-adapter'
 
@@ -28,11 +28,13 @@ export default MnObject.extend(
       if (this.view && this.updateView(transition)) return
       let ViewClass = this.viewClass || View
       let viewOptions = _.result(this, 'viewOptions', {})
-      if (!(ViewClass.prototype instanceof View)) {
+      if (!(ViewClass.prototype instanceof View) &&
+        !(ViewClass.prototype instanceof CollectionView)) {
         if (_.isFunction(ViewClass)) {
           ViewClass = ViewClass.call(this)
         }
-        if (!(ViewClass.prototype instanceof View)) {
+        if (!(ViewClass.prototype instanceof View) &&
+          !(ViewClass.prototype instanceof CollectionView)) {
           viewOptions = _.extend({}, ViewClass, viewOptions)
           ViewClass = View
         }

--- a/src/route.js
+++ b/src/route.js
@@ -27,14 +27,13 @@ export default MnObject.extend(
     renderView (region, transition) {
       if (this.view && this.updateView(transition)) return
       let ViewClass = this.viewClass || View
+      const isMarionetteView = proto => proto instanceof View || proto instanceof CollectionView
       let viewOptions = _.result(this, 'viewOptions', {})
-      if (!(ViewClass.prototype instanceof View) &&
-        !(ViewClass.prototype instanceof CollectionView)) {
+      if (!isMarionetteView(ViewClass.prototype)) {
         if (_.isFunction(ViewClass)) {
           ViewClass = ViewClass.call(this)
         }
-        if (!(ViewClass.prototype instanceof View) &&
-          !(ViewClass.prototype instanceof CollectionView)) {
+        if (!isMarionetteView(ViewClass.prototype)) {
           viewOptions = _.extend({}, ViewClass, viewOptions)
           ViewClass = View
         }

--- a/test/render.js
+++ b/test/render.js
@@ -38,6 +38,12 @@ let LeafView = Mn.View.extend({
   }
 })
 
+let LeafCollectionView = Mn.CollectionView.extend({
+  template: function () {
+    return 'Collection'
+  }
+})
+
 describe('rootRegion', () => {
   afterEach(() => {
     router.destroy()
@@ -85,6 +91,7 @@ describe('Render', () => {
         route('leaf2', { routeClass: LeafRoute, viewClass: LeafView })
       })
       route('root3', { routeClass: RootRoute })
+      route('collection', { viewClass: LeafCollectionView })
     }
     router.map(routes)
     router.listen()
@@ -200,6 +207,15 @@ describe('Render', () => {
           expect(spy).to.be.calledTwice
           expect($('#main').html()).to.be.equal('<div><div class="child-view"></div></div>')
         })
+      })
+    })
+
+    describe('for a CollectionView', function () {
+      it('can load successfully', function (done) {
+        router.transitionTo('collection').then(function () {
+          expect($('#main').html()).to.be.equal('<div>Collection</div>')
+          done()
+        }).catch(done)
       })
     })
   })


### PR DESCRIPTION
This one's an actual bug that I think I know how to fix - passing a CollectionView in for `viewClass` didn't seem to be working because `Marionette.CollectionView instanceof Marionette.View === false`. I added another check for that in the `renderView` routine, as well as a test that failed in the older version.

Let me know if anything needs to be changed from this!