### PR TITLE
Added transition:error trigger when error inside async `renderViews` occurs

### DIFF
--- a/src/cherrytree-adapter.js
+++ b/src/cherrytree-adapter.js
@@ -171,15 +171,15 @@ function renderViews (mnRoutes, activated, transition) {
     // Try to render the view
     try {
       mnRoute.renderView(parentRegion, transition)
-    }
-    // If something fails during rendering, emit a transition:error event
-    catch (err) {
+    } catch (err) {
+      // If something fails during rendering, emit a transition:error event
       routerChannel.trigger('transition:error', transition, err)
       return // continue iterating and avoid throwing the error below
     }
 
-    // If the view did not successfully render, or if no parentRegion exists, throw an error
-    if (!mnRoute.hasRenderedView() && !parentRegion) {
+    // If the view was not attached and rendered, or if no parentRegion exists, throw an error
+    const routeHasRenderedView = mnRoute.view && mnRoute.view.isRendered()
+    if (!routeHasRenderedView && !parentRegion) {
       throw new Error('No root outlet region defined')
     }
   })
@@ -297,7 +297,7 @@ const middleware = {
           loadPromise.then(function () {
             renderViews(mnRoutes, activated, transition)
             resolve()
-          }).catch(function (err) {
+          }).catch(function () {
             renderViews(mnRoutes, activated, transition)
             resolve()
           })

--- a/src/cherrytree-adapter.js
+++ b/src/cherrytree-adapter.js
@@ -283,8 +283,8 @@ const middleware = {
           loadPromise.then(function () {
             renderViews(mnRoutes, activated, transition)
             resolve()
-          }).catch(function () {
-            renderViews(mnRoutes, activated, transition)
+          }).catch(function (err) {
+            routerChannel.trigger('transition:error', transition, err)
             resolve()
           })
         })

--- a/src/route.js
+++ b/src/route.js
@@ -45,18 +45,26 @@ export default MnObject.extend(
         }
         this.view = void 0
       })
+
+      // If region is falsy, no rootRegion was defined; only acceptable if view was pre-rendered.
+      // Return here without assigning `this.view` so `hasRenderedView` below returns false
       if (region) {
         region.show(view)
-      } else {
-        // if region is undefined means no rootRegion is defined
-        // accept a pre-rendered view in those situations throwing otherwise
-        if (!view.isRendered()) throw new Error('No root outlet region defined')
       }
+      else if (!view.isRendered()) {
+        return
+      }
+
       this.view = view
       routerChannel.trigger('route:render', this)
       if (this.viewEvents) {
         bindEvents(this, view, this.viewEvents)
       }
+    },
+
+    // Returns true if view is attached to route and has already been rendered
+    hasRenderedView () {
+      return this.view && this.view.isRendered()
     },
 
     updateView () {

--- a/src/route.js
+++ b/src/route.js
@@ -47,11 +47,10 @@ export default MnObject.extend(
       })
 
       // If region is falsy, no rootRegion was defined; only acceptable if view was pre-rendered.
-      // Return here without assigning `this.view` so `hasRenderedView` below returns false
+      // Return here without assigning `this.view` so cherrytree-adapter:renderViews throws an error correctly
       if (region) {
         region.show(view)
-      }
-      else if (!view.isRendered()) {
+      } else if (!view.isRendered()) {
         return
       }
 
@@ -60,11 +59,6 @@ export default MnObject.extend(
       if (this.viewEvents) {
         bindEvents(this, view, this.viewEvents)
       }
-    },
-
-    // Returns true if view is attached to route and has already been rendered
-    hasRenderedView () {
-      return this.view && this.view.isRendered()
     },
 
     updateView () {

--- a/test/events.js
+++ b/test/events.js
@@ -6,6 +6,7 @@ import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import _ from 'underscore'
 import Radio from 'backbone.radio'
+import { View } from 'backbone.marionette'
 import { Route, Router } from '../src/index'
 
 let expect = chai.expect
@@ -121,7 +122,7 @@ describe('Events', () => {
   })
 
   describe('transition:error', () => {
-    it('should be called when an error occurs in middle of transaction', function () {
+    it('should be called when an error occurs in middle of transition', function () {
       let spy = sinon.spy()
 
       Radio.channel('router').on('transition:error', spy)
@@ -129,6 +130,26 @@ describe('Events', () => {
       RootRoute.prototype.activate = function () {
         throw new Error('xx')
       }
+
+      return router.transitionTo('root').catch(function () {
+        return Promise.resolve().then(function () {
+          expect(spy).to.be.calledOnce
+        })
+      })
+    })
+
+    it('should be called when an error occurs in render chained to async load', function () {
+      let spy = sinon.spy()
+
+      Radio.channel('router').on('transition:error', spy)
+
+      RootRoute.prototype.load = async function () {}
+
+      RootRoute.prototype.ViewClass = View.extend({
+        onRender: function () {
+          throw new Error('xx')
+        }
+      })
 
       return router.transitionTo('root').catch(function () {
         return Promise.resolve().then(function () {

--- a/test/events.js
+++ b/test/events.js
@@ -6,7 +6,6 @@ import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import _ from 'underscore'
 import Radio from 'backbone.radio'
-import { View } from 'backbone.marionette'
 import { Route, Router } from '../src/index'
 
 let expect = chai.expect
@@ -130,26 +129,6 @@ describe('Events', () => {
       RootRoute.prototype.activate = function () {
         throw new Error('xx')
       }
-
-      return router.transitionTo('root').catch(function () {
-        return Promise.resolve().then(function () {
-          expect(spy).to.be.calledOnce
-        })
-      })
-    })
-
-    it('should be called when an error occurs in render chained to async load', function () {
-      let spy = sinon.spy()
-
-      Radio.channel('router').on('transition:error', spy)
-
-      RootRoute.prototype.load = async function () {}
-
-      RootRoute.prototype.ViewClass = View.extend({
-        onRender: function () {
-          throw new Error('xx')
-        }
-      })
 
       return router.transitionTo('root').catch(function () {
         return Promise.resolve().then(function () {

--- a/test/render.js
+++ b/test/render.js
@@ -44,6 +44,12 @@ let LeafCollectionView = Mn.CollectionView.extend({
   }
 })
 
+let ErrorView = Mn.View.extend({
+  onRender: function () {
+    throw new Error('xx')
+  }
+})
+
 describe('rootRegion', () => {
   afterEach(() => {
     router.destroy()
@@ -92,6 +98,7 @@ describe('Render', () => {
       })
       route('root3', { routeClass: RootRoute })
       route('collection', { viewClass: LeafCollectionView })
+      route('error', { viewClass: ErrorView })
     }
     router.map(routes)
     router.listen()
@@ -288,6 +295,18 @@ describe('Render', () => {
         _.defer(function () {
           expect(spy).to.not.be.called
           done()
+        })
+      })
+    })
+
+    it('should emit transition:error for errors during View.render', function () {
+      let spy = sinon.spy()
+
+      Radio.channel('router').on('transition:error', spy)
+
+      return router.transitionTo('error').catch(function () {
+        return Promise.resolve().then(function () {
+          expect(spy).to.be.calledOnce
         })
       })
     })


### PR DESCRIPTION
Refs #22

Less sure about this one, and I'm not entirely certain what you meant by "returning loadPromise directly" since it actually looks like it is returned.

I ran into issues with the... "Lifecycle hooks load should not cancel the transition when returned promise is rejected" [test](https://github.com/blikblum/marionette.routing/blob/master/test/lifecycle.js#L325) whenever I tried to let the error trickle up or introduce a `reject()` in [this Promise](https://github.com/blikblum/marionette.routing/blob/fa399af0ac5b7b9b093802f896441a28f9ccd4be/src/cherrytree-adapter.js#L282), so I've just removed the duplicate call to `renderViews` and replaced it with a `transition:error` call.

Trying to balance the "Emitted when a transition fails" definition of the "transition:error" event in [events.md](https://github.com/blikblum/marionette.routing/blob/master/docs/events.md) and the "triggered for any error while routing" definition in [errors.md](https://github.com/blikblum/marionette.routing/blob/master/docs/errors.md), I don't _think_ this breaks any patterns, and all the tests pass now.

I definitely foresee followup changes requested here, so let me know what's needed!
